### PR TITLE
Fixed installation of openswoole extension (now with sockets support)…

### DIFF
--- a/swoole/Dockerfile
+++ b/swoole/Dockerfile
@@ -1,34 +1,6 @@
 ARG BASE_IMAGE=latest
-FROM php:${BASE_IMAGE}
+FROM columbusinteractive/php:${BASE_IMAGE}
 LABEL maintainer="hello@columbus-interactive.de"
 
-RUN apt-get update && apt-get install git -y
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-
-RUN chmod +x /usr/local/bin/install-php-extensions
-RUN install-php-extensions openswoole inotify
-RUN install-php-extensions bcmath \
-        bz2 \
-        calendar \
-        exif \
-        gd \
-        intl \
-        ldap \
-        memcached \
-        mysqli \
-        opcache \
-        pdo_mysql \
-        pdo_pgsql \
-        pgsql \
-        redis \
-        soap \
-        sockets \
-        xsl \
-        zip \
-        imagick \
-        gettext
-
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-RUN php -r "if (hash_file('sha384', 'composer-setup.php') === '906a84df04cea2aa72f40b5f787e49f22d4c2f19492ac310e8cba5b96ac8b64115ac402c8cd292b8a03482574915d1a8') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-RUN php composer-setup.php --install-dir=/usr/local/bin --filename=composer
-RUN php -r "unlink('composer-setup.php');"
+RUN IPE_DONT_ENABLE=1 install-php-extensions openswoole \
+    && docker-php-ext-enable --ini-name xx-php-ext-openswoole.ini openswoole


### PR DESCRIPTION
The old Dockerfile installed openswoole without sockets support; thats the reason why it worked.
The new Dockerfile uses the base Dockerfile and installs openswoole with a "xx-" prefix for the ini-file. Then openswool will be loaded after the sockets extension and will work with sockets support.